### PR TITLE
Doc & Tests

### DIFF
--- a/DependencyInjection/ForumExtension.php
+++ b/DependencyInjection/ForumExtension.php
@@ -22,8 +22,6 @@ class ForumExtension extends Extension
                 $loader->load('orm.xml');
                 break;
             case 'odm':
-                // TODO: Implement the ODM database driver
-                throw new \Exception(sprintf('Sorry, the ODM database driver is not implemented yet.'));
                 $loader->load('odm.xml');
                 break;
             default:

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,45 @@
 The ForumBundle offers a simple Symfony2 forum.
 
 It's currently under *intensive* development.
+
+## Installation
+
+### Add ForumBundle to your src/Bundle dir
+
+    git submodule add git://github.com/Herzult/ForumBundle.git src/Bundle/ForumBundle
+
+### Add ForumBundle to your application kernel
+
+    // app/AppKernel.php
+    public function registerBundles()
+    {
+        return array(
+            // ...
+            new Bundle\ForumBundle\ForumBundle(),
+            // ...
+        );
+    }
+
+### Choose ORM or ODM database driver
+
+    # app/config.yml
+    forum.config:
+        db_driver: orm # can be orm or odm
+
+or if you prefer xml
+
+    # app/config.xml
+    <forum:config db_driver="orm"/> <!-- can be orm or odm -->
+
+### Add authentication routes
+
+If you want ready to use routing, include the builtin routes:
+
+    # app/config/routing.yml
+    forum:
+        resource: ForumBundle/Resources/config/routing.xml
+
+in xml
+
+    # app/config/routing.xml
+    <import resource="ForumBundle/Resources/config/routing.xml"/>

--- a/Resources/config/odm.xml
+++ b/Resources/config/odm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://www.symfony-project.org/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.symfony-project.org/schema/dic/services http://www.symfony-project.org/schema/dic/services/services-1.0.xsd">
+    
+    <parameters>
+        <parameter key="forum.category_object.class">Bundle\ForumBundle\Document\Category</parameter>
+        <parameter key="forum.topic_object.class">Bundle\ForumBundle\Document\Topic</parameter>
+        <parameter key="forum.post_object.class">Bundle\ForumBundle\Document\Post</parameter>
+    </parameters>
+
+    <services>
+        <!-- Object Manager Service -->
+        <service id="forum.object_manager" alias="doctrine.odm.mongodb.document_manager" />
+    </services>
+    
+</container>

--- a/Test/WebTestCase.php
+++ b/Test/WebTestCase.php
@@ -37,6 +37,10 @@ class WebTestCase extends \Symfony\Bundle\FrameworkBundle\Test\WebTestCase
             $kernel->boot();
         }
 
+        if(!$kernel->getContainer()->has($name)) {
+            $this->markTestSkipped(sprintf('The service %s is not available', $name));
+        }
+
         return $kernel->getContainer()->get($name);
     }
 

--- a/Tests/Entity/CategoryTest.php
+++ b/Tests/Entity/CategoryTest.php
@@ -50,9 +50,7 @@ class CategoryTest extends WebTestCase
 
     public function testNumTopics()
     {
-        $kernel = $this->createKernel();
-        $kernel->boot();
-        $em = $kernel->getContainer()->get('Doctrine.ORM.EntityManager');
+        $em = $this->getService('Doctrine.ORM.EntityManager');
 
         $category = new Category();
         $category->setName(\uniqid('Test category '));


### PR DESCRIPTION
There already are a lot of good tests. That's nice. I skipped the ORM tests when no ORM is available, like in my current MongoDB project.

I'd like to make these tests generic to ORM and ODM. Like here: http://github.com/knplabs/DoctrineUserBundle/blob/master/Tests/DAO/UserTest.php

Because the tested methods live in the generic DAO classes.

Will you pull changes if I do that?
