### PR TITLE
Removed 'unique=true' on category's name for ORM.

### DIFF
--- a/Resources/config/doctrine/Category.orm.xml
+++ b/Resources/config/doctrine/Category.orm.xml
@@ -14,7 +14,7 @@
             <generator strategy="AUTO" />
         </id>
 
-        <field name="name" column="name" type="string" unique="true" />
+        <field name="name" column="name" type="string" />
         <field name="description" column="description" type="string" nullable="true" />
         <field name="slug" column="slug" type="string" unique="true" />
         <field name="position" column="position" type="integer" />


### PR DESCRIPTION
The slug has to be unique but not the name. It was ok for ODM but not for ORM. This change just make consistance between ODM and ORM.

Reference issue #25
