### PR TITLE
Fix css asset path (relative path)

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -6,5 +6,5 @@
 
 {% block stylesheets %}
     {{ parent() }}
-    <link rel="stylesheet" type="text/css" href="{{ asset('/bundles/herzultforum/css/forum.css') }}" />
+    <link rel="stylesheet" type="text/css" href="{{ asset('bundles/herzultforum/css/forum.css') }}" />
 {% endblock %}


### PR DESCRIPTION
It fix an little issue with the css path.

For a site @ http://site.com/forum/
The previous path was not found : `http://site.com/bundles/herzultforum/css/forum.css`

The relative path give `http://site.com/forums/bundles/herzultforum/css/forum.css`
